### PR TITLE
Fix sloppy number/address check

### DIFF
--- a/src/io/forsta/securesms/util/Util.java
+++ b/src/io/forsta/securesms/util/Util.java
@@ -57,7 +57,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;


### PR DESCRIPTION
Add regex to check UUID. Allow fallback to normal number processing for SMS messages.