### PR TITLE
Set local number fix.

### DIFF
--- a/src/io/forsta/ccsm/ForstaPreferences.java
+++ b/src/io/forsta/ccsm/ForstaPreferences.java
@@ -10,11 +10,13 @@ import com.h6ah4i.android.compat.utils.SharedPreferencesJsonStringSetWrapperUtil
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.w3c.dom.Text;
 
 import io.forsta.ccsm.api.CcsmApi;
 import io.forsta.ccsm.api.ForstaJWT;
 import io.forsta.securesms.BuildConfig;
 import io.forsta.securesms.util.Base64;
+import io.forsta.securesms.util.TextSecurePreferences;
 
 import java.io.IOException;
 import java.util.Date;
@@ -66,6 +68,8 @@ public class ForstaPreferences {
 
   public static void setRegisteredForsta(Context context, String value) {
     setStringPreference(context, API_KEY, value);
+    ForstaJWT jwt = new ForstaJWT(value);
+    TextSecurePreferences.setLocalNumber(context, jwt.getUserInfo().uid);
   }
 
   public static String getRegisteredKey(Context context) {

--- a/src/io/forsta/securesms/service/RegistrationService.java
+++ b/src/io/forsta/securesms/service/RegistrationService.java
@@ -120,7 +120,6 @@ public class RegistrationService extends Service {
     String signalingKey = Util.getSecret(52);
     Context context = getApplicationContext();
     String addr = ForstaPreferences.getUserId(context);
-    TextSecurePreferences.setLocalNumber(context, addr);
     setState(new RegistrationState(RegistrationState.STATE_CONNECTING));
     try {
       ForstaServiceAccountManager accountManager = TextSecureCommunicationFactory.createManager(this);


### PR DESCRIPTION
Fixes an issue where directory sync happening before TextSecurePreferences.getLocalNumber() had a value, creating an empty directory entry with no number.