### PR TITLE
Registration updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,8 @@ android {
         applicationId 'io.forsta.relay'
         minSdkVersion 21
         targetSdkVersion 22
-        versionName "0.1.92"
-        versionCode 192
+        versionName "0.1.93"
+        versionCode 193
         multiDexEnabled true
         buildConfigField "long", "BUILD_TIMESTAMP", getLastCommitTimestamp() + "L"
         buildConfigField "String", "RECAPTCHA_KEY", "\"6LetY10UAAAAAKugwBLDP31SVLcl1iem9K1fqJlA\""

--- a/res/layout/activity_login.xml
+++ b/res/layout/activity_login.xml
@@ -19,9 +19,16 @@
         android:layout_height="wrap_content"
         android:id="@+id/forsta_login_title"
         android:text="@string/forsta_login_title"
-        android:layout_marginBottom="30dp"
+        android:layout_marginBottom="20dp"
+        android:layout_gravity="center_horizontal"
         style="@style/TextAppearance.AppCompat.Medium"/>
-
+    <TextView android:id="@+id/forsta_login_error"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="An error has occurred."
+        android:textColor="@color/red"
+        android:visibility="gone"
+        android:layout_gravity="center_horizontal" />
     <LinearLayout
         android:id="@+id/forsta_login_send_link_container"
         android:layout_width="match_parent"

--- a/res/layout/registration_progress_activity.xml
+++ b/res/layout/registration_progress_activity.xml
@@ -25,6 +25,12 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:text="@string/forsta_login_provision_error_title"
+                android:layout_marginBottom="10dp"
+                android:textStyle="bold"/>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:text="@string/forsta_login_provision_error"
                 android:layout_marginBottom="30dp"/>
 

--- a/res/layout/registration_progress_activity.xml
+++ b/res/layout/registration_progress_activity.xml
@@ -13,6 +13,45 @@
             android:gravity="center" >
 
         <LinearLayout
+            android:id="@+id/provisioning_failure_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginLeft="16dip"
+            android:layout_marginRight="16dip"
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:weightSum="1">
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/forsta_login_provision_error"
+                android:layout_marginBottom="30dp"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1.13"
+                android:gravity="center_horizontal"
+                android:orientation="horizontal"
+                android:padding="5dp">
+
+                <Button
+                    android:id="@+id/provisioning_continue_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Continue"
+                    android:paddingRight="20dp"/>
+
+                <Button
+                    android:id="@+id/provisioning_retry_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Retry" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
             android:id="@+id/connectivity_failure_layout"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -7,7 +7,8 @@
     <string name="please_wait">Please wait...</string>
 
     <!-- Forsta Strings -->
-    <string name="forsta_login_title">Join Forsta</string>
+    <string name="forsta_login_title">Login to Forsta</string>
+    <string name="forsta_login_title_join">Join Forsta</string>
     <string name="forsta_login_account_firstname_label">First Name</string>
     <string name="forsta_login_account_fullname_label">Full Name</string>
     <string name="forsta_login_account_username_label">Username</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -33,7 +33,8 @@
     <string name="forsta_login_login_button">Submit</string>
     <string name="forsta_login_verify_token_button">Verify Token</string>
     <string name="forsta_login_tryagain_button">Try Again</string>
-    <string name="forsta_login_provision_error">Unable to communicate with any other registered devices. If you have another registered phone or web app, please make sure one of them is running and try again. If you choose to continue, other phone devices will no longer be registered.</string>
+    <string name="forsta_login_provision_error_title">Unable to communicate with any other registered devices.</string>
+    <string name="forsta_login_provision_error">If you have another registered phone or web app, please make sure one of them is running and try again. If you choose to continue, other phone devices will no longer be registered.</string>
     <string name="forsta_login_provision_continue">Continue Registration</string>
     <!-- AbstractNotificationBuilder -->
     <string name="AbstractNotificationBuilder_new_message">New message</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="forsta_login_login_button">Submit</string>
     <string name="forsta_login_verify_token_button">Verify Token</string>
     <string name="forsta_login_tryagain_button">Try Again</string>
+    <string name="forsta_login_provision_error">Unable to communicate with any other registered devices. If you have another registered phone or web app, please make sure one of them is running and try again. If you choose to continue, other phone devices will no longer be registered.</string>
+    <string name="forsta_login_provision_continue">Continue Registration</string>
     <!-- AbstractNotificationBuilder -->
     <string name="AbstractNotificationBuilder_new_message">New message</string>
 

--- a/src/io/forsta/ccsm/LoginActivity.java
+++ b/src/io/forsta/ccsm/LoginActivity.java
@@ -73,6 +73,7 @@ public class LoginActivity extends BaseActionBarActivity implements Executor {
   private LinearLayout createAccountContainer;
   private LinearLayout tryAgainContainer;
   private TextView tryAgainMessage;
+  private TextView errorMessage;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -124,6 +125,7 @@ public class LoginActivity extends BaseActionBarActivity implements Executor {
     mAccountEmail = (EditText) findViewById(R.id.forsta_login_account_email);
     mAccountPassword = (EditText) findViewById(R.id.forsta_login_account_password);
     mPassword = (EditText) findViewById(R.id.forsta_login_password);
+    errorMessage = (TextView) findViewById(R.id.forsta_login_error);
 
     createAccountContainer = (LinearLayout) findViewById(R.id.create_account_button_container);
     tryAgainContainer = (LinearLayout) findViewById(R.id.forsta_login_tryagain_container);
@@ -385,12 +387,23 @@ public class LoginActivity extends BaseActionBarActivity implements Executor {
 
   private void showAccountForm() {
     ForstaPreferences.setForstaLoginPending(LoginActivity.this, false);
+    mLoginTitle.setText(R.string.forsta_login_title_join);
     mSendLinkFormContainer.setVisibility(View.GONE);
     mVerifyFormContainer.setVisibility(View.GONE);
     passwordAuthContainer.setVisibility(View.GONE);
     tryAgainContainer.setVisibility(View.GONE);
     mAccountFormContainer.setVisibility(View.VISIBLE);
     hideProgressBar();
+  }
+
+  private void showError(String error) {
+    errorMessage.setText(error);
+    errorMessage.setVisibility(View.VISIBLE);
+  }
+
+  private void hideError() {
+    errorMessage.setText("");
+    errorMessage.setVisibility(View.GONE);
   }
 
   private void showProgressBar() {
@@ -493,6 +506,7 @@ public class LoginActivity extends BaseActionBarActivity implements Executor {
     @Override
     protected void onPostExecute(JSONObject jsonObject) {
       Context context = LoginActivity.this;
+      hideError();
 
       try {
         if (jsonObject.has("token")) {
@@ -515,6 +529,7 @@ public class LoginActivity extends BaseActionBarActivity implements Executor {
         } else if (jsonObject.has("error")) {
           String errorResult = jsonObject.getString("error");
           String messages = ForstaUtils.parseErrors(new JSONObject(errorResult));
+          showError(messages);
           hideProgressBar();
           Toast.makeText(LoginActivity.this, "Login Error: "  + messages, Toast.LENGTH_LONG).show();
         } else {

--- a/src/io/forsta/ccsm/LoginActivity.java
+++ b/src/io/forsta/ccsm/LoginActivity.java
@@ -2,6 +2,7 @@ package io.forsta.ccsm;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Paint;
 import android.os.AsyncTask;
@@ -10,6 +11,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -47,6 +49,8 @@ import io.forsta.securesms.ConversationListActivity;
 import io.forsta.securesms.R;
 import io.forsta.ccsm.api.CcsmApi;
 import io.forsta.securesms.crypto.MasterSecretUtil;
+import io.forsta.securesms.database.DatabaseFactory;
+import io.forsta.securesms.database.ThreadDatabase;
 import io.forsta.securesms.util.TextSecurePreferences;
 import io.forsta.securesms.util.Util;
 
@@ -600,12 +604,20 @@ public class LoginActivity extends BaseActionBarActivity implements Executor {
       if (jsonObject.has("method")) {
         String method = jsonObject.optString("method", "unknown");
         hideProgressBar();
-        Toast.makeText(LoginActivity.this, "Check your " + method + " for a password reset link.", Toast.LENGTH_LONG).show();
-        // broadcastListner();
+        handleResetSuccess(method);
       } else {
         hideProgressBar();
+        showError("Unable to reset password.");
         Toast.makeText(LoginActivity.this, "Unable to reset password.", Toast.LENGTH_LONG).show();
       }
     }
+  }
+
+  private void handleResetSuccess(String method) {
+    new AlertDialog.Builder(LoginActivity.this)
+        .setTitle("Password Reset")
+        .setMessage("Check your " + method + " for a password reset link.")
+        .setNeutralButton("OK", null)
+        .show();
   }
 }

--- a/src/io/forsta/ccsm/LoginActivity.java
+++ b/src/io/forsta/ccsm/LoginActivity.java
@@ -349,6 +349,7 @@ public class LoginActivity extends BaseActionBarActivity implements Executor {
   }
 
   private void joinForsta(String captcha) {
+    hideError();
     String fullName = mAccountFullName.getText().toString().trim();
     String tagSlug = mAccountTagSlug.getText().toString().trim();
     String phone = mAccountPhone.getText().toString().trim();
@@ -580,7 +581,7 @@ public class LoginActivity extends BaseActionBarActivity implements Executor {
           String errorResult = jsonObject.getString("error");
           String messages = ForstaUtils.parseErrors(new JSONObject(errorResult));
           hideProgressBar();
-          Toast.makeText(LoginActivity.this, "Error: "  + messages, Toast.LENGTH_LONG).show();
+          showError(messages);
         } else {
           hideProgressBar();
           Toast.makeText(LoginActivity.this, "Sorry. A communications error has occurred.", Toast.LENGTH_LONG).show();

--- a/src/io/forsta/ccsm/PasswordActivity.java
+++ b/src/io/forsta/ccsm/PasswordActivity.java
@@ -14,4 +14,8 @@ public class PasswordActivity extends PassphraseRequiredActionBarActivity {
     getSupportActionBar().setTitle(R.string.AndroidManifest__authentication);
     setContentView(R.layout.activity_password);
   }
+
+  private void initializeView() {
+
+  }
 }

--- a/src/io/forsta/ccsm/api/AutoProvision.java
+++ b/src/io/forsta/ccsm/api/AutoProvision.java
@@ -29,7 +29,6 @@ import io.forsta.securesms.push.TextSecureCommunicationFactory;
  * Created by john on 2/2/2018.
  */
 
-// Rename this to AutoProvision or something else.
 public class AutoProvision {
   private static final String TAG = AutoProvision.class.getSimpleName();
 

--- a/src/io/forsta/ccsm/api/CcsmApi.java
+++ b/src/io/forsta/ccsm/api/CcsmApi.java
@@ -255,7 +255,9 @@ public class CcsmApi {
   private static JSONObject getUsersByPhone(Context context, Set<String> phoneNumbers) {
     String query = "";
     try {
-      query = "?phone_in=" + URLEncoder.encode(TextUtils.join(",", phoneNumbers), "UTF-8");
+      if (!phoneNumbers.isEmpty()) {
+        query = "?phone_in=" + URLEncoder.encode(TextUtils.join(",", phoneNumbers), "UTF-8");
+      }
     } catch (UnsupportedEncodingException e) {
       e.printStackTrace();
     }

--- a/src/io/forsta/securesms/service/RegistrationService.java
+++ b/src/io/forsta/securesms/service/RegistrationService.java
@@ -119,6 +119,7 @@ public class RegistrationService extends Service {
 
   private void handleCcsmRegistrationIntent(Intent intent) {
     markAsVerifying(true);
+    boolean provisionContinue = intent.getBooleanExtra("provision_continue", false);
     int registrationId = TextSecurePreferences.getLocalRegistrationId(this);
     if (registrationId == 0) {
       registrationId = KeyHelper.generateRegistrationId(false);
@@ -135,7 +136,7 @@ public class RegistrationService extends Service {
     try {
       final ForstaServiceAccountManager accountManager = TextSecureCommunicationFactory.createManager(this);
       boolean isMultiDevice = CcsmApi.hasDevices(context);
-      if (isMultiDevice) {
+      if (!provisionContinue && isMultiDevice) {
         AutoProvision autoProvision = AutoProvision.getInstance(context);
         autoProvision.start();
         autoProvision.setProvisionCallbacks(new AutoProvision.ProvisionCallbacks() {
@@ -168,8 +169,8 @@ public class RegistrationService extends Service {
 
           @Override
           public void onFailure(String message) {
-            Log.w(TAG, "Provisioning FAILED! : " + message);
-            setState(new RegistrationState(RegistrationState.STATE_NETWORK_ERROR));
+            Log.w(TAG, "Failed to contact any devices for provisioning! : " + message);
+            setState(new RegistrationState(RegistrationState.STATE_PROVISION_ERROR));
             broadcastComplete(false);
           }
         });
@@ -284,6 +285,7 @@ public class RegistrationService extends Service {
     public static final int STATE_TIMER                =  3;
     public static final int STATE_COMPLETE             =  4;
     public static final int STATE_NETWORK_ERROR        =  6;
+    public static final int STATE_PROVISION_ERROR      =  16;
 
     public static final int STATE_GCM_UNSUPPORTED      =  8;
     public static final int STATE_GCM_REGISTERING      =  9;


### PR DESCRIPTION
On provision failure with other registered devices, allow hard registration option.
Display static errors instead of Android toasts for devices that don't show toasts.