### PR TITLE
Fix notification clearing.

### DIFF
--- a/src/io/forsta/securesms/notifications/MessageNotifier.java
+++ b/src/io/forsta/securesms/notifications/MessageNotifier.java
@@ -171,7 +171,7 @@ public class MessageNotifier {
 
     try {
       telcoCursor = DatabaseFactory.getMmsSmsDatabase(context).getUnread();
-      pushCursor  = DatabaseFactory.getPushDatabase(context).getPending();
+      pushCursor  = includePushDatabase ? DatabaseFactory.getPushDatabase(context).getPending() : null;
 
       if ((telcoCursor == null || telcoCursor.isAfterLast()) &&
           (pushCursor == null || pushCursor.isAfterLast()))


### PR DESCRIPTION
The "PushDatabase" which is basically the incoming message queue should
be ignored when processing notifications inside the handleMessage
context.  Failure to do so will mean that it will ALWAYS think there are
pending messages to process even though it is most likely already on the
last one.  The system already included the information that we should
NOT include the push database, but it was only being used for some other
bit of instrumentation.  I just use the same flag and ignore the push
database when deciding if the user is all caught up on notifications.

Fixes #296